### PR TITLE
Ability to print only error logs

### DIFF
--- a/net_utilities.h
+++ b/net_utilities.h
@@ -38,14 +38,18 @@
 #include "core/math/math_funcs.h"
 #include "core/templates/local_vector.h"
 #include "core/variant/variant.h"
+#include "core/config/project_settings.h"
 
 class Node;
 
 #ifdef DEBUG_ENABLED
-#define NET_DEBUG_PRINT(msg) \
-	print_line(String("[Net] ") + msg)
-#define NET_DEBUG_WARN(msg) \
-	WARN_PRINT(String("[Net] ") + msg)
+#define NET_DEBUG_PRINT(msg)                                                                    \
+	if (!ProjectSettings::get_singleton()->get_setting("NetworkSynchronizer/show_only_errors")) \
+		print_line(String("[Net] ") + msg)                                                                                     
+	
+#define NET_DEBUG_WARN(msg)                                                                     \
+	if (!ProjectSettings::get_singleton()->get_setting("NetworkSynchronizer/show_only_errors")) \
+		WARN_PRINT(String("[Net] ") + msg)                                                                                     
 #define NET_DEBUG_ERR(msg) \
 	ERR_PRINT(String("[Net] ") + msg)
 #else

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -54,6 +54,7 @@ void initialize_network_synchronizer_module(ModuleInitializationLevel p_level) {
 
 	GLOBAL_DEF("NetworkSynchronizer/debug_server_speedup", false);
 	GLOBAL_DEF("NetworkSynchronizer/debug_doll_speedup", false);
+	GLOBAL_DEF("NetworkSynchronizer/show_only_errors", false);
 }
 
 void uninitialize_network_synchronizer_module(ModuleInitializationLevel p_level) {

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -2006,7 +2006,9 @@ void ClientSynchronizer::process() {
 
 #ifdef DEBUG_ENABLED
 	if (unlikely(Engine::get_singleton()->get_frames_per_second() < physics_ticks_per_second)) {
-		WARN_PRINT("Current FPS is " + itos(Engine::get_singleton()->get_frames_per_second()) + ", but the minimum required FPS is " + itos(physics_ticks_per_second) + ", the client is unable to generate enough inputs for the server.");
+		if (!ProjectSettings::get_singleton()->get_setting("NetworkSynchronizer/show_only_errors")) {
+			WARN_PRINT("Current FPS is " + itos(Engine::get_singleton()->get_frames_per_second()) + ", but the minimum required FPS is " + itos(physics_ticks_per_second) + ", the client is unable to generate enough inputs for the server.");
+		}
 	}
 #endif
 


### PR DESCRIPTION
NetSync has tendency to be a bit spammy in the output console
This commit adds project setting that allows to disable any prints which aren't errors