### PR TITLE
Update Map to HashMap in tests

### DIFF
--- a/tests/test_interpolator.h
+++ b/tests/test_interpolator.h
@@ -60,19 +60,19 @@ TEST_CASE_TEMPLATE("[Modules][Interpolator] Interpolation", T, int, real_t, Vect
 	fractions.push_back(0.25);
 	fractions.push_back(0.75);
 
-	Map<real_t, real_t> values;
+	HashMap<real_t, real_t> values;
 	values.insert(0.0, 1.0);
 	values.insert(-1.0, 1.0);
 	values.insert(0.0, -1.0);
 	values.insert(10, 15);
 
 	Interpolator interpolator;
-	for (const Map<real_t, real_t>::Element *E = values.front(); E; E = E->next()) {
+	for (KeyValue<real_t, real_t> &E : values) {
 		for (uint32_t j = 0; j < fractions.size(); ++j) {
 			// Skip custom interpolator for now
 			for (int k = Interpolator::FALLBACK_INTERPOLATE; k < Interpolator::FALLBACK_CUSTOM_INTERPOLATOR; ++k) {
-				const T first_value = generate_value<T>(E->key());
-				const T second_value = generate_value<T>(E->value());
+				const T first_value = generate_value<T>(E.key);
+				const T second_value = generate_value<T>(E.value);
 
 				interpolator.reset();
 				const int variable_id = interpolator.register_variable(T(), static_cast<Interpolator::Fallback>(k));


### PR DESCRIPTION
In [this commit](https://github.com/GodotNetworking/network_synchronizer/commit/5e5aaca0442d4c5472abc7947a4b0e3b97e32e15), Set was updated to HashSet, but HashMap was forgotten about. The only instances of HashMap were in the tests, so this caused the tests to not build. This PR fixes this by using HashMap in the tests with the new iterators.