### PR TITLE
NetworkedController will skip some checks when server controlled

### DIFF
--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -215,6 +215,23 @@ void NetworkedController::set_server_controlled(bool p_server_controlled) {
 		// set it.
 		server_controlled = p_server_controlled;
 	}
+#ifdef DEBUG_ENABLED
+	if(GDVIRTUAL_IS_OVERRIDDEN(_collect_inputs) == false && server_controlled == false) {
+		WARN_PRINT("In your script you must inherit the virtual method `_collect_inputs` to correctly use the `NetworkedController`.");
+	}
+	
+	if(GDVIRTUAL_IS_OVERRIDDEN(_controller_process) == false && server_controlled == false) {
+		WARN_PRINT("In your script you must inherit the virtual method `_controller_process` to correctly use the `NetworkedController`.");
+	}
+
+	if(GDVIRTUAL_IS_OVERRIDDEN(_are_inputs_different) == false && server_controlled == false) {
+		WARN_PRINT("In your script you must inherit the virtual method `_are_inputs_different` to correctly use the `NetworkedController`.");
+	}
+
+	if(GDVIRTUAL_IS_OVERRIDDEN(_count_input_size) == false && server_controlled == false) {
+		WARN_PRINT("In your script you must inherit the virtual method `_count_input_size` to correctly use the `NetworkedController`.");
+	}
+#endif
 }
 
 bool NetworkedController::get_server_controlled() const {
@@ -575,10 +592,10 @@ void NetworkedController::_notification(int p_what) {
 				return;
 			}
 
-			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_collect_inputs) == false, "In your script you must inherit the virtual method `_collect_inputs` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_controller_process) == false, "In your script you must inherit the virtual method `_controller_process` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_are_inputs_different) == false, "In your script you must inherit the virtual method `_are_inputs_different` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_count_input_size) == false, "In your script you must inherit the virtual method `_count_input_size` to correctly use the `NetworkedController`.");
+			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_collect_inputs) == false && server_controlled == false, "In your script you must inherit the virtual method `_collect_inputs` to correctly use the `NetworkedController`.");
+			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_controller_process) == false && server_controlled == false, "In your script you must inherit the virtual method `_controller_process` to correctly use the `NetworkedController`.");
+			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_are_inputs_different) == false && server_controlled == false, "In your script you must inherit the virtual method `_are_inputs_different` to correctly use the `NetworkedController`.");
+			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_count_input_size) == false && server_controlled == false, "In your script you must inherit the virtual method `_count_input_size` to correctly use the `NetworkedController`.");
 			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_collect_epoch_data) == false, "In your script you must inherit the virtual method `_collect_epoch_data` to correctly use the `NetworkedController`.");
 			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_setup_interpolator) == false, "In your script you must inherit the virtual method `_setup_interpolator` to correctly use the `NetworkedController`.");
 			ERR_FAIL_COND_MSG(GDVIRTUAL_IS_OVERRIDDEN(_parse_epoch_data) == false, "In your script you must inherit the virtual method `_parse_epoch_data` to correctly use the `NetworkedController`.");


### PR DESCRIPTION
There is no need to overwrite some methods of NetworkedController when controller is controlled by the server.
This will fix some error prints that can be seen on the server and on the client upon connecting to the server 